### PR TITLE
Replace the old api with the new one on heath

### DIFF
--- a/lua/Trans/health.lua
+++ b/lua/Trans/health.lua
@@ -1,9 +1,9 @@
 local Trans      = require 'Trans'
 local health, fn = vim.health, vim.fn
 
-local ok         = health.report_ok
-local warn       = health.report_warn
-local error      = health.report_error
+local ok         = health.ok
+local warn       = health.warn
+local error      = health.error
 local has        = fn.has
 local executable = fn.executable
 


### PR DESCRIPTION
CHECKHEALTH

health#report_error vim.health.report_error() Use vim.health.error() instead.
health#report_info vim.health.report_info() Use vim.health.info() instead.
health#report_ok vim.health.report_ok() Use vim.health.ok() instead.
health#report_start vim.health.report_start() Use vim.health.start() instead.
health#report_warn vim.health.report_warn() Use vim.health.warn() instead.

https://neovim.io/doc/user/deprecated.html#deprecated-0.10