### PR TITLE
fix(core/backend/hover): fix offline/online exception handling, punctuation processing, and UI freezes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
         run: |
           test -d _neovim || {
             mkdir -p _neovim
-            curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+            curl -sSL --fail "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            rev: nightly/nvim-linux64.tar.gz
+            rev: nightly/nvim-linux-x86_64.tar.gz
           - os: ubuntu-22.04
             rev: v0.7.2/nvim-linux64.tar.gz
           - os: ubuntu-22.04

--- a/lua/Trans/backend/baidu.lua
+++ b/lua/Trans/backend/baidu.lua
@@ -27,6 +27,11 @@ local Trans = require 'Trans'
 ---@param data TransData
 ---@return BaiduQuery
 function M.get_query(data)
+    if not M.app_id or not M.app_passwd then
+        vim.notify('百度翻译未配置 API 密钥 (Trans.json)', vim.log.levels.WARN)
+        return nil
+    end
+
     local tmp  = M.app_id .. data.str .. M.salt .. M.app_passwd
     local sign = Trans.util.md5.sumhexa(tmp)
 

--- a/lua/Trans/backend/offline.lua
+++ b/lua/Trans/backend/offline.lua
@@ -25,12 +25,27 @@ function M.query(data)
         return
     end
 
-    local res = dict:select(db_name, {
-        where = { word = data.str },
-        keys  = M.query_field,
-        limit = 1,
-    })[1]
+    if vim.fn.filereadable(path) == 0 then
+        vim.notify('离线词典未安装，可运行 :lua require("Trans").install() 安装词典', vim.log.levels.WARN)
+        data.result.offline = false
+        return
+    end
 
+    local ok, rows = pcall(function()
+        return dict:select(db_name, {
+            where = { word = data.str },
+            keys  = M.query_field,
+            limit = 1,
+        })
+    end)
+
+    if not ok or not rows then
+        vim.notify('离线词典数据库查询失败，可运行 :lua require("Trans").install() 重新安装', vim.log.levels.WARN)
+        data.result.offline = false
+        return
+    end
+
+    local res = rows[1]
     data.result.offline = res and M.formatter(res) or false
 end
 

--- a/lua/Trans/backend/offline.lua
+++ b/lua/Trans/backend/offline.lua
@@ -22,6 +22,7 @@ local M = {
 ---@overload fun(TransData): TransResult
 function M.query(data)
     if data.is_word == false or data.from == 'zh' then
+        data.result.offline = false
         return
     end
 

--- a/lua/Trans/backend/youdao.lua
+++ b/lua/Trans/backend/youdao.lua
@@ -30,6 +30,10 @@ function M.get_query(data)
     local salt    = M.salt
     local curtime = tostring(os.time())
 
+    if not app_id or not M.app_passwd then
+        vim.notify('有道翻译未配置 API 密钥 (Trans.json)', vim.log.levels.WARN)
+        return nil
+    end
 
     local chars = vim.str_utf_pos(str)
     local count = #chars

--- a/lua/Trans/core/buffer.lua
+++ b/lua/Trans/core/buffer.lua
@@ -135,6 +135,16 @@ function buffer:setline(nodes, one_index)
     end
 end
 
+---Process lines within the buffer to handle Chinese punctuation
+function buffer:process_chinese_punctuation()
+    local util = require('Trans.core.util')
+    local lines = self:lines(1, -1)
+    for i, line in ipairs(lines) do
+        lines[i] = util.replace_chinese_punctuation(line)
+    end
+    api.nvim_buf_set_lines(self.bufnr, 0, -1, false, lines)
+end
+
 buffer.__index = function(self, key)
     local res = buffer[key]
     if res then

--- a/lua/Trans/core/translate.lua
+++ b/lua/Trans/core/translate.lua
@@ -13,19 +13,30 @@ end
 ---@param data TransData @data
 ---@param backend TransOnlineBackend @backend
 local function do_query(data, backend)
-    -- TODO : template method for online query
     local name      = backend.name
     local uri       = backend.uri
     local method    = backend.method
     local formatter = backend.formatter
-    local query     = backend.get_query(data)
-    local header    = type(backend.header) == 'function' and backend.header(data) or backend.header
+
+    local q_ok, query = pcall(backend.get_query, data)
+    if not q_ok or not query then
+        data.result[name] = false
+        return
+    end
+
+    local header
+    if backend.header then
+        local h_ok, h_res = pcall(function()
+            return type(backend.header) == 'function' and backend.header(data) or backend.header
+        end)
+        header = h_ok and h_res or nil
+    end
 
     local function handle(output)
         local status, body = pcall(vim.json.decode, output.body)
         if not status or not body then
             if not Trans.conf.debug then
-                backend.debug(body)
+                if backend.debug then pcall(backend.debug, body) end
                 data.trace[name] = output
             end
 
@@ -33,16 +44,21 @@ local function do_query(data, backend)
             return
         end
 
-        -- vim.print(data.result[name])
-        data.result[name] = formatter(body, data)
+        local f_ok, res = pcall(formatter, body, data)
+        data.result[name] = f_ok and res or false
     end
 
-    Trans.curl[method](uri, {
-        query = query,
-        callback = handle,
-        header = header,
-    })
-    -- Hook ?
+    local c_ok = pcall(function()
+        Trans.curl[method](uri, {
+            query = query,
+            callback = handle,
+            header = header,
+        })
+    end)
+
+    if not c_ok then
+        data.result[name] = false
+    end
 end
 
 ---@type table<string, fun(data: TransData):boolean>

--- a/lua/Trans/core/util.lua
+++ b/lua/Trans/core/util.lua
@@ -132,9 +132,11 @@ end
 ---@param str string
 ---@return boolean
 function M.is_english(str)
-    local char = { str:byte(1, -1) }
-    for i = 1, #str do
-        if char[i] > 128 then
+    local len = vim.fn.strchars(str)
+    for i = 0, len - 1 do
+        local c = vim.fn.strgetchar(str, i)
+        -- CJK Unified Ideographs range: 0x4E00 - 0x9FFF, 0x3400 - 0x4DBF, 0x20000 - 0x323AF
+        if (c >= 0x4E00 and c <= 0x9FFF) or (c >= 0x3400 and c <= 0x4DBF) or (c >= 0x20000 and c <= 0x323AF) then
             return false
         end
     end

--- a/lua/Trans/core/util.lua
+++ b/lua/Trans/core/util.lua
@@ -3,6 +3,23 @@ local fn, api = vim.fn, vim.api
 ---@class TransUtil
 local M = require 'Trans'.metatable 'util'
 
+---Replace full-width Chinese punctuation with English punctuation
+---@param str string The input text containing Chinese punctuation
+---@return string The processed text with replaced punctuation
+function M.replace_chinese_punctuation(str)
+    local replacements = {
+        ['，'] = ',', -- Full-width comma to half-width comma
+        ['。'] = '.', -- Full-width period to half-width period
+        ['！'] = '!', -- Full-width exclamation to half-width
+        ['？'] = '?', -- Full-width question to half-width
+    }
+
+    for k, v in pairs(replacements) do
+        str = str:gsub(k, v)
+    end
+    return str
+end
+
 ---Get the range of visual modes
 ---@return table
 function M.get_range()

--- a/lua/Trans/frontend/hover/init.lua
+++ b/lua/Trans/frontend/hover/init.lua
@@ -213,7 +213,18 @@ function M:process(data)
     local buffer = self.buffer
 
     if opts.auto_play then
-        (data.from == 'en' and data.str or result.definition[1]):play()
+        local text_to_play
+        if data.from == 'en' then
+            text_to_play = data.str
+        elseif result and result.definition and result.definition[1] then
+            text_to_play = result.definition[1]
+        elseif result and result.translation and result.translation[1] then
+            text_to_play = result.translation[1]
+        end
+
+        if text_to_play and type(text_to_play) == 'string' then
+            pcall(function() text_to_play:play() end)
+        end
     end
 
     -- vim.pretty_print(result)

--- a/lua/Trans/frontend/hover/init.lua
+++ b/lua/Trans/frontend/hover/init.lua
@@ -156,8 +156,13 @@ function M:fallback()
     buffer:wipe()
     buffer[1] = util.center(fallback_msg, opts.width)
     buffer:add_highlight(1, 'TransFailed')
-    if not self.window then
+    if not self.window or not self.window:is_valid() then
         self:init_window {
+            height = buffer:line_count(),
+            width = self.opts.width,
+        }
+    else
+        self.window:resize {
             height = buffer:line_count(),
             width = self.opts.width,
         }

--- a/lua/test/buffer_spec.lua
+++ b/lua/test/buffer_spec.lua
@@ -142,3 +142,17 @@ describe('buffer:lines()', with_buffer(function(buffer)
         assert.are.equal(lines[2], 'line 3')
     end)
 end))
+
+describe('buffer:process_chinese_punctuation()', with_buffer(function(buffer)
+    before_each(function()
+        buffer:wipe()
+    end)
+
+    it('replaces Chinese punctuation in buffer lines', function()
+        buffer[1] = '你好，世界。'
+        buffer[2] = '欢迎！你在这里吗？'
+        buffer:process_chinese_punctuation()
+        assert.are.equal(buffer[1], '你好,世界.')
+        assert.are.equal(buffer[2], '欢迎!你在这里吗?')
+    end)
+end))

--- a/lua/test/util_spec.lua
+++ b/lua/test/util_spec.lua
@@ -90,3 +90,11 @@ describe('util.is_word', function()
         end
     end)
 end)
+
+describe('util.replace_chinese_punctuation', function()
+    it('replaces Chinese punctuation with English punctuation', function()
+        local input = '你好，世界。欢迎！你在这里吗？'
+        local expected = '你好,世界.欢迎!你在这里吗?'
+        assert.are.equal(expected, util.replace_chinese_punctuation(input))
+    end)
+end)


### PR DESCRIPTION
## Summary

This PR resolves several critical issues regarding Chinese punctuation processing, missing SQLite database handling, online query failures, and language misclassification caused by non-ASCII symbols.

## Key Changes & Improvements

1. Chinese Punctuation Replacement & Refactoring (util / buffer) 
	- Implemented M.replace_chinese_punctuation in Trans.core.util to convert full-width Chinese punctuation (， 。 ！ ？) to half-width English punctuation. ⚬ Refactored buffer:process_chinese_punctuation() as a standalone method in Trans.core.buffer. ⚬ Fixed test block nesting structure in lua/test/util_spec.lua and added unit tests for buffer Chinese punctuation processing.
2. Graceful Handling for Missing/Corrupted Offline Database (backend/offline) 
	- Added pre-checks for ultimate.db readability before querying. 
	- Wrapped dict:select in pcall to gracefully handle missing tables or corrupted SQLite database files. 
	- Shows a friendly warning via vim.notify instead of throwing an unhandled Lua exception.
3. Prevent UI Freezes on Online Translation Failures (translate / hover) 
	- Wrapped do_query and backend.get_query in pcall to prevent coroutine crashes when online API calls fail or keys are unconfigured. 
	- Added explicit API key checks in youdao and baidu backends prior to string concatenation. 
	- Fixed hover:fallback() to properly resize the hover window when self.window was already initialized by wait().
4. Accurate Language Detection & Robust auto_play (util / hover) 
	- Refactored M.is_english(str) to detect Chinese characters using CJK Unicode ranges instead of byte > 128 (preventing non-ASCII quotes/symbols like “ ” ’ — from misclassifying English as Chinese). 
	- Added defensive checks in auto_play for result.definition and result.translation fields with pcall protection to prevent UI crashes.

## Commit History

1. 0baaf90 fix(util/buffer): fix chinese punctuation replacement and syntax errors 
	- Implement M.replace_chinese_punctuation in Trans.core.util 
	- Refactor buffer:process_chinese_punctuation into Trans.core.buffer 
	- Fix test scope structure in util_spec and add unit tests for buffer Chinese punctuation processing
2. 11ab6b1 fix(backend/offline): handle missing database/table gracefully with warning notification 
	- Check if ultimate.db exists before querying 
	- Wrap dict:select in pcall to catch missing table/sqlite errors 
	- Show warning notification instead of throwing an unhandled exception
3. ec42155 fix(translate/hover): prevent UI freeze when online query fails or is unconfigured 
	- Wrap do_query and get_query calls in pcall to prevent coroutine crashes 
	- Check API keys in youdao and baidu backends before string formatting 
	- Resize hover window in fallback() when window was initialized by wait()
4. f2eeba6 fix(util/hover): fix language detection for non-English symbols and guard auto_play 
	- Detect Chinese via CJK Unicode ranges instead of byte > 128 
	- Guard auto_play against nil result.definition access to prevent UI crashes

## Testing

- Ran test suite via Plenary (make test): All 24 unit tests across util_spec.lua, buffer_spec.lua, and window_spec.lua passed successfully.